### PR TITLE
Centralize service clickthrough handling

### DIFF
--- a/BonusVarsler.user.js
+++ b/BonusVarsler.user.js
@@ -191,6 +191,7 @@
     adblockerDetected: { message: "Adblocker funnet!" },
     checkingAdblock: { message: "Sjekker..." },
     checkAdblockAgain: { message: "Sjekk p\xE5 nytt" },
+    trackingUnavailable: { message: "Sporing utilgjengelig" },
     adblockWarning: { message: "Adblock oppdaget!" },
     adblockNote: { message: "Du m\xE5 skru av adblock for at sporingen skal fungere." },
     // DNB code-based
@@ -909,7 +910,33 @@
     }
     return null;
   }
-  function findBestOffer(feed, currentHost, enabledServices, services = SERVICES_FALLBACK) {
+  function normalizePathPrefix(pathname, caseSensitive = false) {
+    const normalized = pathname.startsWith("/") ? pathname : `/${pathname}`;
+    const withoutTrailingSlash = normalized.replace(/\/+$/, "") || "/";
+    return caseSensitive ? withoutTrailingSlash : withoutTrailingSlash.toLowerCase();
+  }
+  function offerMatchesPath(offer, currentPathname) {
+    if (!offer.matchPathPrefix) {
+      return true;
+    }
+    const caseSensitive = Boolean(offer.matchPathCaseSensitive);
+    const currentPath = normalizePathPrefix(currentPathname, caseSensitive);
+    const offerPath = normalizePathPrefix(offer.matchPathPrefix, caseSensitive);
+    if (offerPath === "/") {
+      return currentPath === "/";
+    }
+    return currentPath === offerPath || currentPath.startsWith(`${offerPath}/`);
+  }
+  function getOfferPathSpecificity(offer) {
+    if (!offer.matchPathPrefix) {
+      return -1;
+    }
+    return normalizePathPrefix(
+      offer.matchPathPrefix,
+      Boolean(offer.matchPathCaseSensitive)
+    ).length;
+  }
+  function findBestOffer(feed, currentHost, enabledServices, services = SERVICES_FALLBACK, currentPathname = "/") {
     if (!feed?.merchants) {
       return null;
     }
@@ -934,12 +961,17 @@
     }
     if (isUnified && merchant.offers) {
       const availableOffers = merchant.offers.filter(
-        (offer) => enabledServices.includes(offer.serviceId)
+        (offer) => enabledServices.includes(offer.serviceId) && offerMatchesPath(offer, currentPathname)
       );
       if (availableOffers.length === 0) {
         return null;
       }
       availableOffers.sort((a, b) => {
+        const specificityA = getOfferPathSpecificity(a);
+        const specificityB = getOfferPathSpecificity(b);
+        if (specificityA !== specificityB) {
+          return specificityB - specificityA;
+        }
         const rateA = parseCashbackRate(a.cashbackDescription);
         const rateB = parseCashbackRate(b.cashbackDescription);
         return compareCashbackRates(rateA, rateB);
@@ -1011,7 +1043,7 @@
     const messageShownKey = `${MESSAGE_SHOWN_KEY_PREFIX}${currentHost}`;
     sessionStorage2.set(messageShownKey, Date.now().toString());
   }
-  async function initialize(adapters, currentHost) {
+  async function initialize(adapters, currentHost, currentPathname = "/") {
     const { storage, fetcher, i18n } = adapters;
     const settings = new Settings(storage, currentHost);
     await settings.load();
@@ -1029,7 +1061,7 @@
     }
     const enabledServices = settings.getEnabledServices();
     const services = feedManager.getServices();
-    const match = findBestOffer(feed, currentHost, enabledServices, services);
+    const match = findBestOffer(feed, currentHost, enabledServices, services, currentPathname);
     if (!match) {
       return { status: "no-match", settings };
     }
@@ -1445,6 +1477,16 @@
 
 .action-btn:hover {
     background: var(--accent-hover);
+}
+
+.action-btn[aria-disabled="true"] {
+    background: var(--text-muted);
+    cursor: not-allowed;
+    opacity: 0.72;
+}
+
+.action-btn[aria-disabled="true"]:hover {
+    background: var(--text-muted);
 }
 
 /* Adblock warning state */
@@ -2113,6 +2155,89 @@
     }
   }
 
+  // src/ui/utils/clickthrough.ts
+  function encodePathSegment(segment) {
+    let decodedSegment = segment;
+    try {
+      decodedSegment = decodeURIComponent(segment);
+    } catch {
+    }
+    if (decodedSegment === ".") {
+      return "%2E";
+    }
+    if (decodedSegment === "..") {
+      return "%2E%2E";
+    }
+    return encodeURIComponent(decodedSegment);
+  }
+  function getSafeUrlNameForTemplate(templateUrl, urlName) {
+    const placeholderIndex = templateUrl.indexOf("{urlName}");
+    const queryIndex = templateUrl.indexOf("?");
+    if (queryIndex !== -1 && placeholderIndex > queryIndex) {
+      return encodeURIComponent(urlName);
+    }
+    return urlName.split("/").map(encodePathSegment).join("/");
+  }
+  function buildClickthroughUrl(templateUrl, urlName) {
+    if (!templateUrl) {
+      return "";
+    }
+    return templateUrl.includes("{urlName}") ? templateUrl.replace("{urlName}", getSafeUrlNameForTemplate(templateUrl, urlName)) : templateUrl;
+  }
+  function addAllowedHost(allowedHosts, hostname) {
+    if (hostname) {
+      allowedHosts.add(hostname.toLowerCase());
+    }
+  }
+  function collectAllowedClickthroughHosts(service) {
+    const allowedHosts = /* @__PURE__ */ new Set();
+    addAllowedHost(allowedHosts, service.reminderDomain);
+    try {
+      addAllowedHost(allowedHosts, new URL(buildClickthroughUrl(service.clickthroughUrl || "", "")).hostname);
+    } catch {
+    }
+    return allowedHosts;
+  }
+  function isAllowedClickthroughHost(hostname, allowedHosts) {
+    if (allowedHosts.size === 0) {
+      return false;
+    }
+    return allowedHosts.has(hostname.toLowerCase());
+  }
+  function toSafeHttpsUrl(rawUrl, allowedHosts) {
+    const trimmedUrl = rawUrl.trim();
+    if (!trimmedUrl) {
+      return "";
+    }
+    try {
+      const parsedUrl = new URL(trimmedUrl);
+      if (parsedUrl.protocol !== "https:" || !parsedUrl.hostname || !isAllowedClickthroughHost(parsedUrl.hostname, allowedHosts)) {
+        return "";
+      }
+      return parsedUrl.toString();
+    } catch {
+      return "";
+    }
+  }
+  function resolveClickthroughUrl(offerClickthroughUrl, service, urlName) {
+    const allowedHosts = collectAllowedClickthroughHosts(service);
+    const fallbackUrl = buildClickthroughUrl(service.clickthroughUrl || "", urlName);
+    return toSafeHttpsUrl(offerClickthroughUrl || "", allowedHosts) || toSafeHttpsUrl(fallbackUrl, allowedHosts);
+  }
+  function restoreActionButtonHref(actionBtn, href) {
+    if (href) {
+      actionBtn.href = href;
+      actionBtn.target = "_blank";
+      actionBtn.rel = "noopener noreferrer";
+      actionBtn.removeAttribute("aria-disabled");
+    } else {
+      actionBtn.removeAttribute("href");
+      actionBtn.removeAttribute("target");
+      actionBtn.removeAttribute("rel");
+      actionBtn.setAttribute("aria-disabled", "true");
+    }
+  }
+
   // src/ui/views/notification.ts
   function createNotification(options) {
     const { match, settings, services, i18n, fetcher, sessionStorage: sessionStorage2, currentHost, onClose } = options;
@@ -2233,7 +2358,7 @@
         handleHideSite();
       }
     });
-    if (service.type !== "code" && service.type !== "info") {
+    if (service.type !== "code" && service.type !== "info" && actionBtn.getAttribute("aria-disabled") !== "true") {
       const originalHref = actionBtn.getAttribute("href") || "";
       const originalText = actionBtn.childNodes[0]?.textContent || "";
       const handleRecheck = async (e) => {
@@ -2250,16 +2375,14 @@
             if (actionBtn.childNodes[0]) {
               actionBtn.childNodes[0].textContent = i18n.getMessage("adblockerDetected");
             }
-            actionBtn.removeAttribute("href");
-            actionBtn.removeAttribute("target");
+            restoreActionButtonHref(actionBtn, "");
           } else {
             actionBtn.classList.remove("adblock");
             actionBtn.style.animation = "";
             if (actionBtn.childNodes[0]) {
               actionBtn.childNodes[0].textContent = originalText;
             }
-            actionBtn.setAttribute("href", originalHref);
-            actionBtn.setAttribute("target", "_blank");
+            restoreActionButtonHref(actionBtn, originalHref);
           }
         } catch {
           actionBtn.classList.remove("adblock");
@@ -2267,8 +2390,7 @@
           if (actionBtn.childNodes[0]) {
             actionBtn.childNodes[0].textContent = originalText;
           }
-          actionBtn.setAttribute("href", originalHref);
-          actionBtn.setAttribute("target", "_blank");
+          restoreActionButtonHref(actionBtn, originalHref);
         } finally {
           recheckIcon.classList.remove("spinning");
         }
@@ -2285,8 +2407,7 @@
           if (actionBtn.childNodes[0]) {
             actionBtn.childNodes[0].textContent = i18n.getMessage("adblockerDetected");
           }
-          actionBtn.removeAttribute("href");
-          actionBtn.removeAttribute("target");
+          restoreActionButtonHref(actionBtn, "");
         }
       }).catch(() => {
       });
@@ -2417,11 +2538,12 @@
   function createActionButton(match, service, i18n, sessionStorage2, currentHost, content) {
     const actionBtn = document.createElement("a");
     actionBtn.className = "action-btn";
-    const baseUrl = service.clickthroughUrl || "";
-    const clickthroughUrl = baseUrl.includes("{urlName}") ? baseUrl.replace("{urlName}", match.urlName || "") : baseUrl;
-    actionBtn.target = "_blank";
-    actionBtn.rel = "noopener noreferrer";
-    actionBtn.href = clickthroughUrl;
+    const clickthroughUrl = resolveClickthroughUrl(
+      match.offer.clickthroughUrl,
+      service,
+      match.urlName || ""
+    );
+    restoreActionButtonHref(actionBtn, clickthroughUrl);
     if (service.type === "code" && match.offer?.code) {
       actionBtn.classList.add("has-code");
       actionBtn.dataset.copied = "false";
@@ -2432,6 +2554,11 @@
       copyIcon.textContent = "\u{1F4CB}";
       copyIcon.title = i18n.getMessage("copyCode") || "Kopier kode";
       actionBtn.appendChild(copyIcon);
+    } else if (!clickthroughUrl) {
+      const trackingUnavailable = i18n.getMessage("trackingUnavailable");
+      actionBtn.textContent = trackingUnavailable;
+      actionBtn.title = trackingUnavailable;
+      actionBtn.setAttribute("aria-label", trackingUnavailable);
     } else if (service.type === "info") {
       actionBtn.textContent = i18n.getMessage("readMoreAboutDiscount");
     } else {
@@ -2448,14 +2575,25 @@
       recheckIcon.style.display = "none";
     }
     actionBtn.appendChild(recheckIcon);
+    const replayAdblockFeedback = () => {
+      actionBtn.style.animation = "shake 0.3s ease-in-out";
+      actionBtn.addEventListener("animationend", () => {
+        actionBtn.style.animation = "pulse 0.7s infinite alternate ease-in-out";
+      }, { once: true });
+    };
     actionBtn.addEventListener("click", (e) => {
       if (actionBtn.classList.contains("adblock")) {
         e.preventDefault();
-        actionBtn.style.animation = "shake 0.3s ease-in-out";
-        actionBtn.addEventListener("animationend", () => {
-          actionBtn.style.animation = "pulse 0.7s infinite alternate ease-in-out";
-        }, { once: true });
+        replayAdblockFeedback();
         return;
+      }
+      const isDisabled = actionBtn.getAttribute("aria-disabled") === "true";
+      if (isDisabled && service.type !== "code") {
+        e.preventDefault();
+        return;
+      }
+      if (isDisabled) {
+        e.preventDefault();
       }
       sessionStorage2.set(`${MESSAGE_SHOWN_KEY_PREFIX}${currentHost}`, Date.now().toString());
       if (service.type === "info") {
@@ -2973,7 +3111,7 @@
       fetcher: getGMFetch(),
       i18n: getStaticI18n()
     };
-    const result = await initialize(adapters, currentHost);
+    const result = await initialize(adapters, currentHost, window.location.pathname);
     const { storage, fetcher, i18n } = adapters;
     if (result.status === "blocked") {
       return;

--- a/BonusVarsler.user.js
+++ b/BonusVarsler.user.js
@@ -337,6 +337,9 @@
   var CURRENT_VERSION = "8.0";
   var MESSAGE_SHOWN_KEY_PREFIX = "BonusVarsler_MessageShown_";
   var PAGE_VISIT_COUNT_PREFIX = "BonusVarsler_PageVisits_";
+  function getMessageShownKey(currentHost, currentPathname = "/") {
+    return `${MESSAGE_SHOWN_KEY_PREFIX}${currentHost}|${currentPathname || "/"}`;
+  }
   var DEFAULT_POSITION = "bottom-right";
   var DEFAULT_THEME = "light";
   var AD_TEST_URLS = [
@@ -1022,7 +1025,7 @@
   }
 
   // src/main.ts
-  function shouldBailOutEarly(sessionStorage2, currentHost) {
+  function shouldBailOutEarly(sessionStorage2, currentHost, currentPathname = "/") {
     if (window.top !== window.self) return true;
     const pageVisitKey = `${PAGE_VISIT_COUNT_PREFIX}${currentHost}`;
     const currentVisits = parseInt(sessionStorage2.get(pageVisitKey) ?? "0", 10);
@@ -1031,7 +1034,7 @@
     if (newVisitCount <= CONFIG.pageVisitsBeforeCooldown) {
       return false;
     }
-    const messageShownKey = `${MESSAGE_SHOWN_KEY_PREFIX}${currentHost}`;
+    const messageShownKey = getMessageShownKey(currentHost, currentPathname);
     const messageShownTime = sessionStorage2.get(messageShownKey);
     if (messageShownTime) {
       const elapsed = Date.now() - parseInt(messageShownTime, 10);
@@ -1039,8 +1042,8 @@
     }
     return false;
   }
-  function markMessageShown(sessionStorage2, currentHost) {
-    const messageShownKey = `${MESSAGE_SHOWN_KEY_PREFIX}${currentHost}`;
+  function markMessageShown(sessionStorage2, currentHost, currentPathname = "/") {
+    const messageShownKey = getMessageShownKey(currentHost, currentPathname);
     sessionStorage2.set(messageShownKey, Date.now().toString());
   }
   async function initialize(adapters, currentHost, currentPathname = "/") {
@@ -2163,10 +2166,10 @@
     } catch {
     }
     if (decodedSegment === ".") {
-      return "%2E";
+      return "%252E";
     }
     if (decodedSegment === "..") {
-      return "%2E%2E";
+      return "%252E%252E";
     }
     return encodeURIComponent(decodedSegment);
   }
@@ -2240,7 +2243,7 @@
 
   // src/ui/views/notification.ts
   function createNotification(options) {
-    const { match, settings, services, i18n, fetcher, sessionStorage: sessionStorage2, currentHost, onClose } = options;
+    const { match, settings, services, i18n, fetcher, sessionStorage: sessionStorage2, currentHost, currentPathname, onClose } = options;
     const service = match.service;
     const shadowHost = createShadowHost();
     appendToBody(shadowHost);
@@ -2276,7 +2279,15 @@
     reminder.className = "reminder";
     reminder.textContent = i18n.getMessage("rememberTo");
     const checklist = createChecklist(service, i18n);
-    const { actionBtn, recheckIcon } = createActionButton(match, service, i18n, sessionStorage2, currentHost, content);
+    const { actionBtn, recheckIcon } = createActionButton(
+      match,
+      service,
+      i18n,
+      sessionStorage2,
+      currentHost,
+      currentPathname,
+      content
+    );
     const hideSiteLink = document.createElement("span");
     hideSiteLink.className = "hide-site";
     hideSiteLink.textContent = i18n.getMessage("dontShowOnThisSite");
@@ -2535,7 +2546,7 @@
     });
     return checklist;
   }
-  function createActionButton(match, service, i18n, sessionStorage2, currentHost, content) {
+  function createActionButton(match, service, i18n, sessionStorage2, currentHost, currentPathname, content) {
     const actionBtn = document.createElement("a");
     actionBtn.className = "action-btn";
     const clickthroughUrl = resolveClickthroughUrl(
@@ -2595,7 +2606,7 @@
       if (isDisabled) {
         e.preventDefault();
       }
-      sessionStorage2.set(`${MESSAGE_SHOWN_KEY_PREFIX}${currentHost}`, Date.now().toString());
+      sessionStorage2.set(getMessageShownKey(currentHost, currentPathname), Date.now().toString());
       if (service.type === "info") {
         return;
       }
@@ -3101,8 +3112,9 @@
   // src/platform/userscript.ts
   (async function() {
     const currentHost = window.location.hostname;
+    const currentPathname = window.location.pathname;
     const sessionStorage2 = getGMSessionStorage();
-    if (shouldBailOutEarly(sessionStorage2, currentHost)) {
+    if (shouldBailOutEarly(sessionStorage2, currentHost, currentPathname)) {
       return;
     }
     const adapters = {
@@ -3111,7 +3123,7 @@
       fetcher: getGMFetch(),
       i18n: getStaticI18n()
     };
-    const result = await initialize(adapters, currentHost, window.location.pathname);
+    const result = await initialize(adapters, currentHost, currentPathname);
     const { storage, fetcher, i18n } = adapters;
     if (result.status === "blocked") {
       return;
@@ -3164,7 +3176,7 @@
       return;
     }
     const { settings, feedManager, match } = result;
-    markMessageShown(sessionStorage2, currentHost);
+    markMessageShown(sessionStorage2, currentHost, currentPathname);
     createNotification({
       match,
       settings,
@@ -3172,7 +3184,8 @@
       i18n,
       fetcher,
       sessionStorage: sessionStorage2,
-      currentHost
+      currentHost,
+      currentPathname
     });
   })();
 })();

--- a/Trumf-Bonusvarsler-Lite.user.js
+++ b/Trumf-Bonusvarsler-Lite.user.js
@@ -191,6 +191,7 @@
     adblockerDetected: { message: "Adblocker funnet!" },
     checkingAdblock: { message: "Sjekker..." },
     checkAdblockAgain: { message: "Sjekk p\xE5 nytt" },
+    trackingUnavailable: { message: "Sporing utilgjengelig" },
     adblockWarning: { message: "Adblock oppdaget!" },
     adblockNote: { message: "Du m\xE5 skru av adblock for at sporingen skal fungere." },
     // DNB code-based
@@ -909,7 +910,33 @@
     }
     return null;
   }
-  function findBestOffer(feed, currentHost, enabledServices, services = SERVICES_FALLBACK) {
+  function normalizePathPrefix(pathname, caseSensitive = false) {
+    const normalized = pathname.startsWith("/") ? pathname : `/${pathname}`;
+    const withoutTrailingSlash = normalized.replace(/\/+$/, "") || "/";
+    return caseSensitive ? withoutTrailingSlash : withoutTrailingSlash.toLowerCase();
+  }
+  function offerMatchesPath(offer, currentPathname) {
+    if (!offer.matchPathPrefix) {
+      return true;
+    }
+    const caseSensitive = Boolean(offer.matchPathCaseSensitive);
+    const currentPath = normalizePathPrefix(currentPathname, caseSensitive);
+    const offerPath = normalizePathPrefix(offer.matchPathPrefix, caseSensitive);
+    if (offerPath === "/") {
+      return currentPath === "/";
+    }
+    return currentPath === offerPath || currentPath.startsWith(`${offerPath}/`);
+  }
+  function getOfferPathSpecificity(offer) {
+    if (!offer.matchPathPrefix) {
+      return -1;
+    }
+    return normalizePathPrefix(
+      offer.matchPathPrefix,
+      Boolean(offer.matchPathCaseSensitive)
+    ).length;
+  }
+  function findBestOffer(feed, currentHost, enabledServices, services = SERVICES_FALLBACK, currentPathname = "/") {
     if (!feed?.merchants) {
       return null;
     }
@@ -934,12 +961,17 @@
     }
     if (isUnified && merchant.offers) {
       const availableOffers = merchant.offers.filter(
-        (offer) => enabledServices.includes(offer.serviceId)
+        (offer) => enabledServices.includes(offer.serviceId) && offerMatchesPath(offer, currentPathname)
       );
       if (availableOffers.length === 0) {
         return null;
       }
       availableOffers.sort((a, b) => {
+        const specificityA = getOfferPathSpecificity(a);
+        const specificityB = getOfferPathSpecificity(b);
+        if (specificityA !== specificityB) {
+          return specificityB - specificityA;
+        }
         const rateA = parseCashbackRate(a.cashbackDescription);
         const rateB = parseCashbackRate(b.cashbackDescription);
         return compareCashbackRates(rateA, rateB);
@@ -1011,7 +1043,7 @@
     const messageShownKey = `${MESSAGE_SHOWN_KEY_PREFIX}${currentHost}`;
     sessionStorage2.set(messageShownKey, Date.now().toString());
   }
-  async function initialize(adapters, currentHost) {
+  async function initialize(adapters, currentHost, currentPathname = "/") {
     const { storage, fetcher, i18n } = adapters;
     const settings = new Settings(storage, currentHost);
     await settings.load();
@@ -1029,7 +1061,7 @@
     }
     const enabledServices = settings.getEnabledServices();
     const services = feedManager.getServices();
-    const match = findBestOffer(feed, currentHost, enabledServices, services);
+    const match = findBestOffer(feed, currentHost, enabledServices, services, currentPathname);
     if (!match) {
       return { status: "no-match", settings };
     }
@@ -1445,6 +1477,16 @@
 
 .action-btn:hover {
     background: var(--accent-hover);
+}
+
+.action-btn[aria-disabled="true"] {
+    background: var(--text-muted);
+    cursor: not-allowed;
+    opacity: 0.72;
+}
+
+.action-btn[aria-disabled="true"]:hover {
+    background: var(--text-muted);
 }
 
 /* Adblock warning state */
@@ -2113,6 +2155,89 @@
     }
   }
 
+  // src/ui/utils/clickthrough.ts
+  function encodePathSegment(segment) {
+    let decodedSegment = segment;
+    try {
+      decodedSegment = decodeURIComponent(segment);
+    } catch {
+    }
+    if (decodedSegment === ".") {
+      return "%2E";
+    }
+    if (decodedSegment === "..") {
+      return "%2E%2E";
+    }
+    return encodeURIComponent(decodedSegment);
+  }
+  function getSafeUrlNameForTemplate(templateUrl, urlName) {
+    const placeholderIndex = templateUrl.indexOf("{urlName}");
+    const queryIndex = templateUrl.indexOf("?");
+    if (queryIndex !== -1 && placeholderIndex > queryIndex) {
+      return encodeURIComponent(urlName);
+    }
+    return urlName.split("/").map(encodePathSegment).join("/");
+  }
+  function buildClickthroughUrl(templateUrl, urlName) {
+    if (!templateUrl) {
+      return "";
+    }
+    return templateUrl.includes("{urlName}") ? templateUrl.replace("{urlName}", getSafeUrlNameForTemplate(templateUrl, urlName)) : templateUrl;
+  }
+  function addAllowedHost(allowedHosts, hostname) {
+    if (hostname) {
+      allowedHosts.add(hostname.toLowerCase());
+    }
+  }
+  function collectAllowedClickthroughHosts(service) {
+    const allowedHosts = /* @__PURE__ */ new Set();
+    addAllowedHost(allowedHosts, service.reminderDomain);
+    try {
+      addAllowedHost(allowedHosts, new URL(buildClickthroughUrl(service.clickthroughUrl || "", "")).hostname);
+    } catch {
+    }
+    return allowedHosts;
+  }
+  function isAllowedClickthroughHost(hostname, allowedHosts) {
+    if (allowedHosts.size === 0) {
+      return false;
+    }
+    return allowedHosts.has(hostname.toLowerCase());
+  }
+  function toSafeHttpsUrl(rawUrl, allowedHosts) {
+    const trimmedUrl = rawUrl.trim();
+    if (!trimmedUrl) {
+      return "";
+    }
+    try {
+      const parsedUrl = new URL(trimmedUrl);
+      if (parsedUrl.protocol !== "https:" || !parsedUrl.hostname || !isAllowedClickthroughHost(parsedUrl.hostname, allowedHosts)) {
+        return "";
+      }
+      return parsedUrl.toString();
+    } catch {
+      return "";
+    }
+  }
+  function resolveClickthroughUrl(offerClickthroughUrl, service, urlName) {
+    const allowedHosts = collectAllowedClickthroughHosts(service);
+    const fallbackUrl = buildClickthroughUrl(service.clickthroughUrl || "", urlName);
+    return toSafeHttpsUrl(offerClickthroughUrl || "", allowedHosts) || toSafeHttpsUrl(fallbackUrl, allowedHosts);
+  }
+  function restoreActionButtonHref(actionBtn, href) {
+    if (href) {
+      actionBtn.href = href;
+      actionBtn.target = "_blank";
+      actionBtn.rel = "noopener noreferrer";
+      actionBtn.removeAttribute("aria-disabled");
+    } else {
+      actionBtn.removeAttribute("href");
+      actionBtn.removeAttribute("target");
+      actionBtn.removeAttribute("rel");
+      actionBtn.setAttribute("aria-disabled", "true");
+    }
+  }
+
   // src/ui/views/notification.ts
   function createNotification(options) {
     const { match, settings, services, i18n, fetcher, sessionStorage: sessionStorage2, currentHost, onClose } = options;
@@ -2233,7 +2358,7 @@
         handleHideSite();
       }
     });
-    if (service.type !== "code" && service.type !== "info") {
+    if (service.type !== "code" && service.type !== "info" && actionBtn.getAttribute("aria-disabled") !== "true") {
       const originalHref = actionBtn.getAttribute("href") || "";
       const originalText = actionBtn.childNodes[0]?.textContent || "";
       const handleRecheck = async (e) => {
@@ -2250,16 +2375,14 @@
             if (actionBtn.childNodes[0]) {
               actionBtn.childNodes[0].textContent = i18n.getMessage("adblockerDetected");
             }
-            actionBtn.removeAttribute("href");
-            actionBtn.removeAttribute("target");
+            restoreActionButtonHref(actionBtn, "");
           } else {
             actionBtn.classList.remove("adblock");
             actionBtn.style.animation = "";
             if (actionBtn.childNodes[0]) {
               actionBtn.childNodes[0].textContent = originalText;
             }
-            actionBtn.setAttribute("href", originalHref);
-            actionBtn.setAttribute("target", "_blank");
+            restoreActionButtonHref(actionBtn, originalHref);
           }
         } catch {
           actionBtn.classList.remove("adblock");
@@ -2267,8 +2390,7 @@
           if (actionBtn.childNodes[0]) {
             actionBtn.childNodes[0].textContent = originalText;
           }
-          actionBtn.setAttribute("href", originalHref);
-          actionBtn.setAttribute("target", "_blank");
+          restoreActionButtonHref(actionBtn, originalHref);
         } finally {
           recheckIcon.classList.remove("spinning");
         }
@@ -2285,8 +2407,7 @@
           if (actionBtn.childNodes[0]) {
             actionBtn.childNodes[0].textContent = i18n.getMessage("adblockerDetected");
           }
-          actionBtn.removeAttribute("href");
-          actionBtn.removeAttribute("target");
+          restoreActionButtonHref(actionBtn, "");
         }
       }).catch(() => {
       });
@@ -2417,11 +2538,12 @@
   function createActionButton(match, service, i18n, sessionStorage2, currentHost, content) {
     const actionBtn = document.createElement("a");
     actionBtn.className = "action-btn";
-    const baseUrl = service.clickthroughUrl || "";
-    const clickthroughUrl = baseUrl.includes("{urlName}") ? baseUrl.replace("{urlName}", match.urlName || "") : baseUrl;
-    actionBtn.target = "_blank";
-    actionBtn.rel = "noopener noreferrer";
-    actionBtn.href = clickthroughUrl;
+    const clickthroughUrl = resolveClickthroughUrl(
+      match.offer.clickthroughUrl,
+      service,
+      match.urlName || ""
+    );
+    restoreActionButtonHref(actionBtn, clickthroughUrl);
     if (service.type === "code" && match.offer?.code) {
       actionBtn.classList.add("has-code");
       actionBtn.dataset.copied = "false";
@@ -2432,6 +2554,11 @@
       copyIcon.textContent = "\u{1F4CB}";
       copyIcon.title = i18n.getMessage("copyCode") || "Kopier kode";
       actionBtn.appendChild(copyIcon);
+    } else if (!clickthroughUrl) {
+      const trackingUnavailable = i18n.getMessage("trackingUnavailable");
+      actionBtn.textContent = trackingUnavailable;
+      actionBtn.title = trackingUnavailable;
+      actionBtn.setAttribute("aria-label", trackingUnavailable);
     } else if (service.type === "info") {
       actionBtn.textContent = i18n.getMessage("readMoreAboutDiscount");
     } else {
@@ -2448,14 +2575,25 @@
       recheckIcon.style.display = "none";
     }
     actionBtn.appendChild(recheckIcon);
+    const replayAdblockFeedback = () => {
+      actionBtn.style.animation = "shake 0.3s ease-in-out";
+      actionBtn.addEventListener("animationend", () => {
+        actionBtn.style.animation = "pulse 0.7s infinite alternate ease-in-out";
+      }, { once: true });
+    };
     actionBtn.addEventListener("click", (e) => {
       if (actionBtn.classList.contains("adblock")) {
         e.preventDefault();
-        actionBtn.style.animation = "shake 0.3s ease-in-out";
-        actionBtn.addEventListener("animationend", () => {
-          actionBtn.style.animation = "pulse 0.7s infinite alternate ease-in-out";
-        }, { once: true });
+        replayAdblockFeedback();
         return;
+      }
+      const isDisabled = actionBtn.getAttribute("aria-disabled") === "true";
+      if (isDisabled && service.type !== "code") {
+        e.preventDefault();
+        return;
+      }
+      if (isDisabled) {
+        e.preventDefault();
       }
       sessionStorage2.set(`${MESSAGE_SHOWN_KEY_PREFIX}${currentHost}`, Date.now().toString());
       if (service.type === "info") {
@@ -2973,7 +3111,7 @@
       fetcher: getGMFetch(),
       i18n: getStaticI18n()
     };
-    const result = await initialize(adapters, currentHost);
+    const result = await initialize(adapters, currentHost, window.location.pathname);
     const { storage, fetcher, i18n } = adapters;
     if (result.status === "blocked") {
       return;

--- a/Trumf-Bonusvarsler-Lite.user.js
+++ b/Trumf-Bonusvarsler-Lite.user.js
@@ -337,6 +337,9 @@
   var CURRENT_VERSION = "8.0";
   var MESSAGE_SHOWN_KEY_PREFIX = "BonusVarsler_MessageShown_";
   var PAGE_VISIT_COUNT_PREFIX = "BonusVarsler_PageVisits_";
+  function getMessageShownKey(currentHost, currentPathname = "/") {
+    return `${MESSAGE_SHOWN_KEY_PREFIX}${currentHost}|${currentPathname || "/"}`;
+  }
   var DEFAULT_POSITION = "bottom-right";
   var DEFAULT_THEME = "light";
   var AD_TEST_URLS = [
@@ -1022,7 +1025,7 @@
   }
 
   // src/main.ts
-  function shouldBailOutEarly(sessionStorage2, currentHost) {
+  function shouldBailOutEarly(sessionStorage2, currentHost, currentPathname = "/") {
     if (window.top !== window.self) return true;
     const pageVisitKey = `${PAGE_VISIT_COUNT_PREFIX}${currentHost}`;
     const currentVisits = parseInt(sessionStorage2.get(pageVisitKey) ?? "0", 10);
@@ -1031,7 +1034,7 @@
     if (newVisitCount <= CONFIG.pageVisitsBeforeCooldown) {
       return false;
     }
-    const messageShownKey = `${MESSAGE_SHOWN_KEY_PREFIX}${currentHost}`;
+    const messageShownKey = getMessageShownKey(currentHost, currentPathname);
     const messageShownTime = sessionStorage2.get(messageShownKey);
     if (messageShownTime) {
       const elapsed = Date.now() - parseInt(messageShownTime, 10);
@@ -1039,8 +1042,8 @@
     }
     return false;
   }
-  function markMessageShown(sessionStorage2, currentHost) {
-    const messageShownKey = `${MESSAGE_SHOWN_KEY_PREFIX}${currentHost}`;
+  function markMessageShown(sessionStorage2, currentHost, currentPathname = "/") {
+    const messageShownKey = getMessageShownKey(currentHost, currentPathname);
     sessionStorage2.set(messageShownKey, Date.now().toString());
   }
   async function initialize(adapters, currentHost, currentPathname = "/") {
@@ -2163,10 +2166,10 @@
     } catch {
     }
     if (decodedSegment === ".") {
-      return "%2E";
+      return "%252E";
     }
     if (decodedSegment === "..") {
-      return "%2E%2E";
+      return "%252E%252E";
     }
     return encodeURIComponent(decodedSegment);
   }
@@ -2240,7 +2243,7 @@
 
   // src/ui/views/notification.ts
   function createNotification(options) {
-    const { match, settings, services, i18n, fetcher, sessionStorage: sessionStorage2, currentHost, onClose } = options;
+    const { match, settings, services, i18n, fetcher, sessionStorage: sessionStorage2, currentHost, currentPathname, onClose } = options;
     const service = match.service;
     const shadowHost = createShadowHost();
     appendToBody(shadowHost);
@@ -2276,7 +2279,15 @@
     reminder.className = "reminder";
     reminder.textContent = i18n.getMessage("rememberTo");
     const checklist = createChecklist(service, i18n);
-    const { actionBtn, recheckIcon } = createActionButton(match, service, i18n, sessionStorage2, currentHost, content);
+    const { actionBtn, recheckIcon } = createActionButton(
+      match,
+      service,
+      i18n,
+      sessionStorage2,
+      currentHost,
+      currentPathname,
+      content
+    );
     const hideSiteLink = document.createElement("span");
     hideSiteLink.className = "hide-site";
     hideSiteLink.textContent = i18n.getMessage("dontShowOnThisSite");
@@ -2535,7 +2546,7 @@
     });
     return checklist;
   }
-  function createActionButton(match, service, i18n, sessionStorage2, currentHost, content) {
+  function createActionButton(match, service, i18n, sessionStorage2, currentHost, currentPathname, content) {
     const actionBtn = document.createElement("a");
     actionBtn.className = "action-btn";
     const clickthroughUrl = resolveClickthroughUrl(
@@ -2595,7 +2606,7 @@
       if (isDisabled) {
         e.preventDefault();
       }
-      sessionStorage2.set(`${MESSAGE_SHOWN_KEY_PREFIX}${currentHost}`, Date.now().toString());
+      sessionStorage2.set(getMessageShownKey(currentHost, currentPathname), Date.now().toString());
       if (service.type === "info") {
         return;
       }
@@ -3101,8 +3112,9 @@
   // src/platform/userscript.ts
   (async function() {
     const currentHost = window.location.hostname;
+    const currentPathname = window.location.pathname;
     const sessionStorage2 = getGMSessionStorage();
-    if (shouldBailOutEarly(sessionStorage2, currentHost)) {
+    if (shouldBailOutEarly(sessionStorage2, currentHost, currentPathname)) {
       return;
     }
     const adapters = {
@@ -3111,7 +3123,7 @@
       fetcher: getGMFetch(),
       i18n: getStaticI18n()
     };
-    const result = await initialize(adapters, currentHost, window.location.pathname);
+    const result = await initialize(adapters, currentHost, currentPathname);
     const { storage, fetcher, i18n } = adapters;
     if (result.status === "blocked") {
       return;
@@ -3164,7 +3176,7 @@
       return;
     }
     const { settings, feedManager, match } = result;
-    markMessageShown(sessionStorage2, currentHost);
+    markMessageShown(sessionStorage2, currentHost, currentPathname);
     createNotification({
       match,
       settings,
@@ -3172,7 +3184,8 @@
       i18n,
       fetcher,
       sessionStorage: sessionStorage2,
-      currentHost
+      currentHost,
+      currentPathname
     });
   })();
 })();

--- a/_locales/da/messages.json
+++ b/_locales/da/messages.json
@@ -273,6 +273,9 @@
   "checkAdblockAgain": {
     "message": "Tjek igen"
   },
+  "trackingUnavailable": {
+    "message": "Sporing ikke tilgængelig"
+  },
   "back": {
     "message": "← Tilbage"
   },

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -273,6 +273,9 @@
   "checkAdblockAgain": {
     "message": "Check again"
   },
+  "trackingUnavailable": {
+    "message": "Tracking unavailable"
+  },
   "back": {
     "message": "← Back"
   },

--- a/_locales/es/messages.json
+++ b/_locales/es/messages.json
@@ -273,6 +273,9 @@
   "checkAdblockAgain": {
     "message": "Comprobar de nuevo"
   },
+  "trackingUnavailable": {
+    "message": "Seguimiento no disponible"
+  },
   "back": {
     "message": "← Volver"
   },

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -273,6 +273,9 @@
   "checkAdblockAgain": {
     "message": "Vérifier à nouveau"
   },
+  "trackingUnavailable": {
+    "message": "Suivi indisponible"
+  },
   "back": {
     "message": "← Retour"
   },

--- a/_locales/no/messages.json
+++ b/_locales/no/messages.json
@@ -273,6 +273,9 @@
   "checkAdblockAgain": {
     "message": "Sjekk på nytt"
   },
+  "trackingUnavailable": {
+    "message": "Sporing utilgjengelig"
+  },
   "back": {
     "message": "← Tilbake"
   },

--- a/_locales/sv/messages.json
+++ b/_locales/sv/messages.json
@@ -273,6 +273,9 @@
   "checkAdblockAgain": {
     "message": "Kontrollera igen"
   },
+  "trackingUnavailable": {
+    "message": "Spårning otillgänglig"
+  },
   "back": {
     "message": "← Tillbaka"
   },

--- a/content.js
+++ b/content.js
@@ -192,6 +192,9 @@
   var CURRENT_VERSION = "8.0";
   var MESSAGE_SHOWN_KEY_PREFIX = "BonusVarsler_MessageShown_";
   var PAGE_VISIT_COUNT_PREFIX = "BonusVarsler_PageVisits_";
+  function getMessageShownKey(currentHost, currentPathname = "/") {
+    return `${MESSAGE_SHOWN_KEY_PREFIX}${currentHost}|${currentPathname || "/"}`;
+  }
   var DEFAULT_POSITION = "bottom-right";
   var DEFAULT_THEME = "light";
   var AD_TEST_URLS = [
@@ -877,7 +880,7 @@
   }
 
   // src/main.ts
-  function shouldBailOutEarly(sessionStorage2, currentHost) {
+  function shouldBailOutEarly(sessionStorage2, currentHost, currentPathname = "/") {
     if (window.top !== window.self) return true;
     const pageVisitKey = `${PAGE_VISIT_COUNT_PREFIX}${currentHost}`;
     const currentVisits = parseInt(sessionStorage2.get(pageVisitKey) ?? "0", 10);
@@ -886,7 +889,7 @@
     if (newVisitCount <= CONFIG.pageVisitsBeforeCooldown) {
       return false;
     }
-    const messageShownKey = `${MESSAGE_SHOWN_KEY_PREFIX}${currentHost}`;
+    const messageShownKey = getMessageShownKey(currentHost, currentPathname);
     const messageShownTime = sessionStorage2.get(messageShownKey);
     if (messageShownTime) {
       const elapsed = Date.now() - parseInt(messageShownTime, 10);
@@ -894,8 +897,8 @@
     }
     return false;
   }
-  function markMessageShown(sessionStorage2, currentHost) {
-    const messageShownKey = `${MESSAGE_SHOWN_KEY_PREFIX}${currentHost}`;
+  function markMessageShown(sessionStorage2, currentHost, currentPathname = "/") {
+    const messageShownKey = getMessageShownKey(currentHost, currentPathname);
     sessionStorage2.set(messageShownKey, Date.now().toString());
   }
   async function initialize(adapters, currentHost, currentPathname = "/") {
@@ -2018,10 +2021,10 @@
     } catch {
     }
     if (decodedSegment === ".") {
-      return "%2E";
+      return "%252E";
     }
     if (decodedSegment === "..") {
-      return "%2E%2E";
+      return "%252E%252E";
     }
     return encodeURIComponent(decodedSegment);
   }
@@ -2095,7 +2098,7 @@
 
   // src/ui/views/notification.ts
   function createNotification(options) {
-    const { match, settings, services, i18n, fetcher, sessionStorage: sessionStorage2, currentHost, onClose } = options;
+    const { match, settings, services, i18n, fetcher, sessionStorage: sessionStorage2, currentHost, currentPathname, onClose } = options;
     const service = match.service;
     const shadowHost = createShadowHost();
     appendToBody(shadowHost);
@@ -2131,7 +2134,15 @@
     reminder.className = "reminder";
     reminder.textContent = i18n.getMessage("rememberTo");
     const checklist = createChecklist(service, i18n);
-    const { actionBtn, recheckIcon } = createActionButton(match, service, i18n, sessionStorage2, currentHost, content);
+    const { actionBtn, recheckIcon } = createActionButton(
+      match,
+      service,
+      i18n,
+      sessionStorage2,
+      currentHost,
+      currentPathname,
+      content
+    );
     const hideSiteLink = document.createElement("span");
     hideSiteLink.className = "hide-site";
     hideSiteLink.textContent = i18n.getMessage("dontShowOnThisSite");
@@ -2390,7 +2401,7 @@
     });
     return checklist;
   }
-  function createActionButton(match, service, i18n, sessionStorage2, currentHost, content) {
+  function createActionButton(match, service, i18n, sessionStorage2, currentHost, currentPathname, content) {
     const actionBtn = document.createElement("a");
     actionBtn.className = "action-btn";
     const clickthroughUrl = resolveClickthroughUrl(
@@ -2450,7 +2461,7 @@
       if (isDisabled) {
         e.preventDefault();
       }
-      sessionStorage2.set(`${MESSAGE_SHOWN_KEY_PREFIX}${currentHost}`, Date.now().toString());
+      sessionStorage2.set(getMessageShownKey(currentHost, currentPathname), Date.now().toString());
       if (service.type === "info") {
         return;
       }
@@ -2957,8 +2968,9 @@
   (async function() {
     "use strict";
     const currentHost = window.location.hostname;
+    const currentPathname = window.location.pathname;
     const sessionStorage2 = getExtensionSessionStorage();
-    if (shouldBailOutEarly(sessionStorage2, currentHost)) {
+    if (shouldBailOutEarly(sessionStorage2, currentHost, currentPathname)) {
       return;
     }
     const adapters = {
@@ -2967,7 +2979,7 @@
       fetcher: getExtensionFetch(),
       i18n: getExtensionI18n()
     };
-    const result = await initialize(adapters, currentHost, window.location.pathname);
+    const result = await initialize(adapters, currentHost, currentPathname);
     const { storage, fetcher, i18n } = adapters;
     if (result.status === "blocked") {
       return;
@@ -3031,7 +3043,7 @@
       return;
     }
     const { settings, feedManager, match } = result;
-    markMessageShown(sessionStorage2, currentHost);
+    markMessageShown(sessionStorage2, currentHost, currentPathname);
     createNotification({
       match,
       settings,
@@ -3039,7 +3051,8 @@
       i18n,
       fetcher,
       sessionStorage: sessionStorage2,
-      currentHost
+      currentHost,
+      currentPathname
     });
   })();
 })();

--- a/content.js
+++ b/content.js
@@ -765,7 +765,33 @@
     }
     return null;
   }
-  function findBestOffer(feed, currentHost, enabledServices, services = SERVICES_FALLBACK) {
+  function normalizePathPrefix(pathname, caseSensitive = false) {
+    const normalized = pathname.startsWith("/") ? pathname : `/${pathname}`;
+    const withoutTrailingSlash = normalized.replace(/\/+$/, "") || "/";
+    return caseSensitive ? withoutTrailingSlash : withoutTrailingSlash.toLowerCase();
+  }
+  function offerMatchesPath(offer, currentPathname) {
+    if (!offer.matchPathPrefix) {
+      return true;
+    }
+    const caseSensitive = Boolean(offer.matchPathCaseSensitive);
+    const currentPath = normalizePathPrefix(currentPathname, caseSensitive);
+    const offerPath = normalizePathPrefix(offer.matchPathPrefix, caseSensitive);
+    if (offerPath === "/") {
+      return currentPath === "/";
+    }
+    return currentPath === offerPath || currentPath.startsWith(`${offerPath}/`);
+  }
+  function getOfferPathSpecificity(offer) {
+    if (!offer.matchPathPrefix) {
+      return -1;
+    }
+    return normalizePathPrefix(
+      offer.matchPathPrefix,
+      Boolean(offer.matchPathCaseSensitive)
+    ).length;
+  }
+  function findBestOffer(feed, currentHost, enabledServices, services = SERVICES_FALLBACK, currentPathname = "/") {
     if (!feed?.merchants) {
       return null;
     }
@@ -790,12 +816,17 @@
     }
     if (isUnified && merchant.offers) {
       const availableOffers = merchant.offers.filter(
-        (offer) => enabledServices.includes(offer.serviceId)
+        (offer) => enabledServices.includes(offer.serviceId) && offerMatchesPath(offer, currentPathname)
       );
       if (availableOffers.length === 0) {
         return null;
       }
       availableOffers.sort((a, b) => {
+        const specificityA = getOfferPathSpecificity(a);
+        const specificityB = getOfferPathSpecificity(b);
+        if (specificityA !== specificityB) {
+          return specificityB - specificityA;
+        }
         const rateA = parseCashbackRate(a.cashbackDescription);
         const rateB = parseCashbackRate(b.cashbackDescription);
         return compareCashbackRates(rateA, rateB);
@@ -867,7 +898,7 @@
     const messageShownKey = `${MESSAGE_SHOWN_KEY_PREFIX}${currentHost}`;
     sessionStorage2.set(messageShownKey, Date.now().toString());
   }
-  async function initialize(adapters, currentHost) {
+  async function initialize(adapters, currentHost, currentPathname = "/") {
     const { storage, fetcher, i18n } = adapters;
     const settings = new Settings(storage, currentHost);
     await settings.load();
@@ -885,7 +916,7 @@
     }
     const enabledServices = settings.getEnabledServices();
     const services = feedManager.getServices();
-    const match = findBestOffer(feed, currentHost, enabledServices, services);
+    const match = findBestOffer(feed, currentHost, enabledServices, services, currentPathname);
     if (!match) {
       return { status: "no-match", settings };
     }
@@ -1301,6 +1332,16 @@
 
 .action-btn:hover {
     background: var(--accent-hover);
+}
+
+.action-btn[aria-disabled="true"] {
+    background: var(--text-muted);
+    cursor: not-allowed;
+    opacity: 0.72;
+}
+
+.action-btn[aria-disabled="true"]:hover {
+    background: var(--text-muted);
 }
 
 /* Adblock warning state */
@@ -1969,6 +2010,89 @@
     }
   }
 
+  // src/ui/utils/clickthrough.ts
+  function encodePathSegment(segment) {
+    let decodedSegment = segment;
+    try {
+      decodedSegment = decodeURIComponent(segment);
+    } catch {
+    }
+    if (decodedSegment === ".") {
+      return "%2E";
+    }
+    if (decodedSegment === "..") {
+      return "%2E%2E";
+    }
+    return encodeURIComponent(decodedSegment);
+  }
+  function getSafeUrlNameForTemplate(templateUrl, urlName) {
+    const placeholderIndex = templateUrl.indexOf("{urlName}");
+    const queryIndex = templateUrl.indexOf("?");
+    if (queryIndex !== -1 && placeholderIndex > queryIndex) {
+      return encodeURIComponent(urlName);
+    }
+    return urlName.split("/").map(encodePathSegment).join("/");
+  }
+  function buildClickthroughUrl(templateUrl, urlName) {
+    if (!templateUrl) {
+      return "";
+    }
+    return templateUrl.includes("{urlName}") ? templateUrl.replace("{urlName}", getSafeUrlNameForTemplate(templateUrl, urlName)) : templateUrl;
+  }
+  function addAllowedHost(allowedHosts, hostname) {
+    if (hostname) {
+      allowedHosts.add(hostname.toLowerCase());
+    }
+  }
+  function collectAllowedClickthroughHosts(service) {
+    const allowedHosts = /* @__PURE__ */ new Set();
+    addAllowedHost(allowedHosts, service.reminderDomain);
+    try {
+      addAllowedHost(allowedHosts, new URL(buildClickthroughUrl(service.clickthroughUrl || "", "")).hostname);
+    } catch {
+    }
+    return allowedHosts;
+  }
+  function isAllowedClickthroughHost(hostname, allowedHosts) {
+    if (allowedHosts.size === 0) {
+      return false;
+    }
+    return allowedHosts.has(hostname.toLowerCase());
+  }
+  function toSafeHttpsUrl(rawUrl, allowedHosts) {
+    const trimmedUrl = rawUrl.trim();
+    if (!trimmedUrl) {
+      return "";
+    }
+    try {
+      const parsedUrl = new URL(trimmedUrl);
+      if (parsedUrl.protocol !== "https:" || !parsedUrl.hostname || !isAllowedClickthroughHost(parsedUrl.hostname, allowedHosts)) {
+        return "";
+      }
+      return parsedUrl.toString();
+    } catch {
+      return "";
+    }
+  }
+  function resolveClickthroughUrl(offerClickthroughUrl, service, urlName) {
+    const allowedHosts = collectAllowedClickthroughHosts(service);
+    const fallbackUrl = buildClickthroughUrl(service.clickthroughUrl || "", urlName);
+    return toSafeHttpsUrl(offerClickthroughUrl || "", allowedHosts) || toSafeHttpsUrl(fallbackUrl, allowedHosts);
+  }
+  function restoreActionButtonHref(actionBtn, href) {
+    if (href) {
+      actionBtn.href = href;
+      actionBtn.target = "_blank";
+      actionBtn.rel = "noopener noreferrer";
+      actionBtn.removeAttribute("aria-disabled");
+    } else {
+      actionBtn.removeAttribute("href");
+      actionBtn.removeAttribute("target");
+      actionBtn.removeAttribute("rel");
+      actionBtn.setAttribute("aria-disabled", "true");
+    }
+  }
+
   // src/ui/views/notification.ts
   function createNotification(options) {
     const { match, settings, services, i18n, fetcher, sessionStorage: sessionStorage2, currentHost, onClose } = options;
@@ -2089,7 +2213,7 @@
         handleHideSite();
       }
     });
-    if (service.type !== "code" && service.type !== "info") {
+    if (service.type !== "code" && service.type !== "info" && actionBtn.getAttribute("aria-disabled") !== "true") {
       const originalHref = actionBtn.getAttribute("href") || "";
       const originalText = actionBtn.childNodes[0]?.textContent || "";
       const handleRecheck = async (e) => {
@@ -2106,16 +2230,14 @@
             if (actionBtn.childNodes[0]) {
               actionBtn.childNodes[0].textContent = i18n.getMessage("adblockerDetected");
             }
-            actionBtn.removeAttribute("href");
-            actionBtn.removeAttribute("target");
+            restoreActionButtonHref(actionBtn, "");
           } else {
             actionBtn.classList.remove("adblock");
             actionBtn.style.animation = "";
             if (actionBtn.childNodes[0]) {
               actionBtn.childNodes[0].textContent = originalText;
             }
-            actionBtn.setAttribute("href", originalHref);
-            actionBtn.setAttribute("target", "_blank");
+            restoreActionButtonHref(actionBtn, originalHref);
           }
         } catch {
           actionBtn.classList.remove("adblock");
@@ -2123,8 +2245,7 @@
           if (actionBtn.childNodes[0]) {
             actionBtn.childNodes[0].textContent = originalText;
           }
-          actionBtn.setAttribute("href", originalHref);
-          actionBtn.setAttribute("target", "_blank");
+          restoreActionButtonHref(actionBtn, originalHref);
         } finally {
           recheckIcon.classList.remove("spinning");
         }
@@ -2141,8 +2262,7 @@
           if (actionBtn.childNodes[0]) {
             actionBtn.childNodes[0].textContent = i18n.getMessage("adblockerDetected");
           }
-          actionBtn.removeAttribute("href");
-          actionBtn.removeAttribute("target");
+          restoreActionButtonHref(actionBtn, "");
         }
       }).catch(() => {
       });
@@ -2273,11 +2393,12 @@
   function createActionButton(match, service, i18n, sessionStorage2, currentHost, content) {
     const actionBtn = document.createElement("a");
     actionBtn.className = "action-btn";
-    const baseUrl = service.clickthroughUrl || "";
-    const clickthroughUrl = baseUrl.includes("{urlName}") ? baseUrl.replace("{urlName}", match.urlName || "") : baseUrl;
-    actionBtn.target = "_blank";
-    actionBtn.rel = "noopener noreferrer";
-    actionBtn.href = clickthroughUrl;
+    const clickthroughUrl = resolveClickthroughUrl(
+      match.offer.clickthroughUrl,
+      service,
+      match.urlName || ""
+    );
+    restoreActionButtonHref(actionBtn, clickthroughUrl);
     if (service.type === "code" && match.offer?.code) {
       actionBtn.classList.add("has-code");
       actionBtn.dataset.copied = "false";
@@ -2288,6 +2409,11 @@
       copyIcon.textContent = "\u{1F4CB}";
       copyIcon.title = i18n.getMessage("copyCode") || "Kopier kode";
       actionBtn.appendChild(copyIcon);
+    } else if (!clickthroughUrl) {
+      const trackingUnavailable = i18n.getMessage("trackingUnavailable");
+      actionBtn.textContent = trackingUnavailable;
+      actionBtn.title = trackingUnavailable;
+      actionBtn.setAttribute("aria-label", trackingUnavailable);
     } else if (service.type === "info") {
       actionBtn.textContent = i18n.getMessage("readMoreAboutDiscount");
     } else {
@@ -2304,14 +2430,25 @@
       recheckIcon.style.display = "none";
     }
     actionBtn.appendChild(recheckIcon);
+    const replayAdblockFeedback = () => {
+      actionBtn.style.animation = "shake 0.3s ease-in-out";
+      actionBtn.addEventListener("animationend", () => {
+        actionBtn.style.animation = "pulse 0.7s infinite alternate ease-in-out";
+      }, { once: true });
+    };
     actionBtn.addEventListener("click", (e) => {
       if (actionBtn.classList.contains("adblock")) {
         e.preventDefault();
-        actionBtn.style.animation = "shake 0.3s ease-in-out";
-        actionBtn.addEventListener("animationend", () => {
-          actionBtn.style.animation = "pulse 0.7s infinite alternate ease-in-out";
-        }, { once: true });
+        replayAdblockFeedback();
         return;
+      }
+      const isDisabled = actionBtn.getAttribute("aria-disabled") === "true";
+      if (isDisabled && service.type !== "code") {
+        e.preventDefault();
+        return;
+      }
+      if (isDisabled) {
+        e.preventDefault();
       }
       sessionStorage2.set(`${MESSAGE_SHOWN_KEY_PREFIX}${currentHost}`, Date.now().toString());
       if (service.type === "info") {
@@ -2830,7 +2967,7 @@
       fetcher: getExtensionFetch(),
       i18n: getExtensionI18n()
     };
-    const result = await initialize(adapters, currentHost);
+    const result = await initialize(adapters, currentHost, window.location.pathname);
     const { storage, fetcher, i18n } = adapters;
     if (result.status === "blocked") {
       return;

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "build": "bun run build.js",
     "build:src": "bun run scripts/bundle.ts",
+    "test": "bun test",
     "typecheck": "tsgo --noEmit"
   },
   "devDependencies": {

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -51,6 +51,10 @@ export const CURRENT_VERSION = "8.0";
 export const MESSAGE_SHOWN_KEY_PREFIX = "BonusVarsler_MessageShown_";
 export const PAGE_VISIT_COUNT_PREFIX = "BonusVarsler_PageVisits_";
 
+export function getMessageShownKey(currentHost: string, currentPathname = "/"): string {
+  return `${MESSAGE_SHOWN_KEY_PREFIX}${currentHost}|${currentPathname || "/"}`;
+}
+
 // Position options
 export type Position = "bottom-right" | "bottom-left" | "top-right" | "top-left";
 export const DEFAULT_POSITION: Position = "bottom-right";

--- a/src/core/feed.ts
+++ b/src/core/feed.ts
@@ -18,6 +18,9 @@ export interface MerchantOffer {
   cashbackDescription: string;
   cashbackDetails?: CashbackDetail[];
   code?: string; // For code-based services (e.g., DNB)
+  clickthroughUrl?: string;
+  matchPathPrefix?: string;
+  matchPathCaseSensitive?: boolean;
 }
 
 /**

--- a/src/core/merchant-matching.ts
+++ b/src/core/merchant-matching.ts
@@ -135,6 +135,39 @@ function tryHost(merchants: Record<string, Merchant>, host: string): Merchant | 
   return null;
 }
 
+function normalizePathPrefix(pathname: string, caseSensitive = false): string {
+  const normalized = pathname.startsWith("/") ? pathname : `/${pathname}`;
+  const withoutTrailingSlash = normalized.replace(/\/+$/, "") || "/";
+  return caseSensitive ? withoutTrailingSlash : withoutTrailingSlash.toLowerCase();
+}
+
+function offerMatchesPath(offer: MerchantOffer, currentPathname: string): boolean {
+  if (!offer.matchPathPrefix) {
+    return true;
+  }
+
+  const caseSensitive = Boolean(offer.matchPathCaseSensitive);
+  const currentPath = normalizePathPrefix(currentPathname, caseSensitive);
+  const offerPath = normalizePathPrefix(offer.matchPathPrefix, caseSensitive);
+
+  if (offerPath === "/") {
+    return currentPath === "/";
+  }
+
+  return currentPath === offerPath || currentPath.startsWith(`${offerPath}/`);
+}
+
+function getOfferPathSpecificity(offer: MerchantOffer): number {
+  if (!offer.matchPathPrefix) {
+    return -1;
+  }
+
+  return normalizePathPrefix(
+    offer.matchPathPrefix,
+    Boolean(offer.matchPathCaseSensitive)
+  ).length;
+}
+
 /**
  * Find merchant by host and return the best offer from enabled services
  */
@@ -142,7 +175,8 @@ export function findBestOffer(
   feed: FeedData,
   currentHost: string,
   enabledServices: string[],
-  services: ServiceRegistry = SERVICES_FALLBACK
+  services: ServiceRegistry = SERVICES_FALLBACK,
+  currentPathname = "/"
 ): MatchResult | null {
   if (!feed?.merchants) {
     return null;
@@ -178,8 +212,10 @@ export function findBestOffer(
   // Handle unified feed format (with offers array)
   if (isUnified && merchant.offers) {
     // Filter to enabled services only
-    const availableOffers = merchant.offers.filter((offer) =>
-      enabledServices.includes(offer.serviceId)
+    const availableOffers = merchant.offers.filter(
+      (offer) =>
+        enabledServices.includes(offer.serviceId) &&
+        offerMatchesPath(offer, currentPathname)
     );
 
     if (availableOffers.length === 0) {
@@ -188,6 +224,12 @@ export function findBestOffer(
 
     // Sort by rate (best first)
     availableOffers.sort((a, b) => {
+      const specificityA = getOfferPathSpecificity(a);
+      const specificityB = getOfferPathSpecificity(b);
+      if (specificityA !== specificityB) {
+        return specificityB - specificityA;
+      }
+
       const rateA = parseCashbackRate(a.cashbackDescription);
       const rateB = parseCashbackRate(b.cashbackDescription);
       return compareCashbackRates(rateA, rateB);

--- a/src/i18n/static-i18n.ts
+++ b/src/i18n/static-i18n.ts
@@ -33,6 +33,7 @@ const NORWEGIAN_MESSAGES: Messages = {
   adblockerDetected: { message: "Adblocker funnet!" },
   checkingAdblock: { message: "Sjekker..." },
   checkAdblockAgain: { message: "Sjekk på nytt" },
+  trackingUnavailable: { message: "Sporing utilgjengelig" },
   adblockWarning: { message: "Adblock oppdaget!" },
   adblockNote: { message: "Du må skru av adblock for at sporingen skal fungere." },
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -77,7 +77,8 @@ export type InitializeResult =
  */
 export async function initialize(
   adapters: PlatformAdapters,
-  currentHost: string
+  currentHost: string,
+  currentPathname = "/"
 ): Promise<InitializeResult> {
   const { storage, fetcher, i18n } = adapters;
 
@@ -108,7 +109,7 @@ export async function initialize(
   // Find best offer for this merchant
   const enabledServices = settings.getEnabledServices();
   const services = feedManager.getServices();
-  const match = findBestOffer(feed, currentHost, enabledServices, services);
+  const match = findBestOffer(feed, currentHost, enabledServices, services, currentPathname);
 
   if (!match) {
     return { status: "no-match", settings };

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,7 +6,7 @@
 import type { StorageAdapter, SessionStorageAdapter } from "./storage/types.js";
 import type { FetchAdapter } from "./network/types.js";
 import type { I18nAdapter } from "./i18n/types.js";
-import { MESSAGE_SHOWN_KEY_PREFIX, PAGE_VISIT_COUNT_PREFIX, CONFIG, STORAGE_KEYS } from "./config/constants.js";
+import { PAGE_VISIT_COUNT_PREFIX, CONFIG, STORAGE_KEYS, getMessageShownKey } from "./config/constants.js";
 import { DOMAIN_ALIASES } from "./config/domain-aliases.js";
 import { Settings } from "./core/settings.js";
 import { FeedManager } from "./core/feed.js";
@@ -28,7 +28,8 @@ export interface PlatformAdapters {
  */
 export function shouldBailOutEarly(
   sessionStorage: SessionStorageAdapter,
-  currentHost: string
+  currentHost: string,
+  currentPathname = "/"
 ): boolean {
   // Skip iframes entirely
   if (window.top !== window.self) return true;
@@ -45,7 +46,7 @@ export function shouldBailOutEarly(
   }
 
   // Check cooldown after N visits
-  const messageShownKey = `${MESSAGE_SHOWN_KEY_PREFIX}${currentHost}`;
+  const messageShownKey = getMessageShownKey(currentHost, currentPathname);
   const messageShownTime = sessionStorage.get(messageShownKey);
   if (messageShownTime) {
     const elapsed = Date.now() - parseInt(messageShownTime, 10);
@@ -60,9 +61,10 @@ export function shouldBailOutEarly(
  */
 export function markMessageShown(
   sessionStorage: SessionStorageAdapter,
-  currentHost: string
+  currentHost: string,
+  currentPathname = "/"
 ): void {
-  const messageShownKey = `${MESSAGE_SHOWN_KEY_PREFIX}${currentHost}`;
+  const messageShownKey = getMessageShownKey(currentHost, currentPathname);
   sessionStorage.set(messageShownKey, Date.now().toString());
 }
 

--- a/src/platform/extension.ts
+++ b/src/platform/extension.ts
@@ -24,10 +24,11 @@ import { SERVICES_FALLBACK } from "../config/services.js";
   "use strict";
 
   const currentHost = window.location.hostname;
+  const currentPathname = window.location.pathname;
   const sessionStorage = getExtensionSessionStorage();
 
   // Early bailout checks
-  if (shouldBailOutEarly(sessionStorage, currentHost)) {
+  if (shouldBailOutEarly(sessionStorage, currentHost, currentPathname)) {
     return;
   }
 
@@ -40,7 +41,7 @@ import { SERVICES_FALLBACK } from "../config/services.js";
   };
 
   // Initialize core
-  const result = await initialize(adapters, currentHost, window.location.pathname);
+  const result = await initialize(adapters, currentHost, currentPathname);
   const { storage, fetcher, i18n } = adapters;
 
   // Blocked sites get no UI at all
@@ -136,7 +137,7 @@ import { SERVICES_FALLBACK } from "../config/services.js";
   const { settings, feedManager, match } = result;
 
   // Mark message as shown
-  markMessageShown(sessionStorage, currentHost);
+  markMessageShown(sessionStorage, currentHost, currentPathname);
 
   // Create and show notification
   createNotification({
@@ -147,5 +148,6 @@ import { SERVICES_FALLBACK } from "../config/services.js";
     fetcher,
     sessionStorage,
     currentHost,
+    currentPathname,
   });
 })();

--- a/src/platform/extension.ts
+++ b/src/platform/extension.ts
@@ -40,7 +40,7 @@ import { SERVICES_FALLBACK } from "../config/services.js";
   };
 
   // Initialize core
-  const result = await initialize(adapters, currentHost);
+  const result = await initialize(adapters, currentHost, window.location.pathname);
   const { storage, fetcher, i18n } = adapters;
 
   // Blocked sites get no UI at all

--- a/src/platform/userscript.ts
+++ b/src/platform/userscript.ts
@@ -38,7 +38,7 @@ import { SERVICES_FALLBACK } from "../config/services.js";
   };
 
   // Initialize core
-  const result = await initialize(adapters, currentHost);
+  const result = await initialize(adapters, currentHost, window.location.pathname);
   const { storage, fetcher, i18n } = adapters;
 
   // Blocked sites get no UI at all

--- a/src/platform/userscript.ts
+++ b/src/platform/userscript.ts
@@ -22,10 +22,11 @@ import { SERVICES_FALLBACK } from "../config/services.js";
 // Immediate IIFE for early bailout
 (async function () {
   const currentHost = window.location.hostname;
+  const currentPathname = window.location.pathname;
   const sessionStorage = getGMSessionStorage();
 
   // Early bailout checks
-  if (shouldBailOutEarly(sessionStorage, currentHost)) {
+  if (shouldBailOutEarly(sessionStorage, currentHost, currentPathname)) {
     return;
   }
 
@@ -38,7 +39,7 @@ import { SERVICES_FALLBACK } from "../config/services.js";
   };
 
   // Initialize core
-  const result = await initialize(adapters, currentHost, window.location.pathname);
+  const result = await initialize(adapters, currentHost, currentPathname);
   const { storage, fetcher, i18n } = adapters;
 
   // Blocked sites get no UI at all
@@ -117,7 +118,7 @@ import { SERVICES_FALLBACK } from "../config/services.js";
   const { settings, feedManager, match } = result;
 
   // Mark message as shown
-  markMessageShown(sessionStorage, currentHost);
+  markMessageShown(sessionStorage, currentHost, currentPathname);
 
   // Create and show notification
   createNotification({
@@ -128,5 +129,6 @@ import { SERVICES_FALLBACK } from "../config/services.js";
     fetcher,
     sessionStorage,
     currentHost,
+    currentPathname,
   });
 })();

--- a/src/ui/styles/notification.css
+++ b/src/ui/styles/notification.css
@@ -165,6 +165,16 @@
     background: var(--accent-hover);
 }
 
+.action-btn[aria-disabled="true"] {
+    background: var(--text-muted);
+    cursor: not-allowed;
+    opacity: 0.72;
+}
+
+.action-btn[aria-disabled="true"]:hover {
+    background: var(--text-muted);
+}
+
 /* Adblock warning state */
 .action-btn.adblock {
     background: #c50000;

--- a/src/ui/utils/clickthrough.ts
+++ b/src/ui/utils/clickthrough.ts
@@ -1,0 +1,117 @@
+import type { Service } from "../../config/services.js";
+
+function encodePathSegment(segment: string): string {
+  let decodedSegment = segment;
+  try {
+    decodedSegment = decodeURIComponent(segment);
+  } catch {
+    // Keep malformed input and encode it below.
+  }
+
+  if (decodedSegment === ".") {
+    return "%2E";
+  }
+
+  if (decodedSegment === "..") {
+    return "%2E%2E";
+  }
+
+  return encodeURIComponent(decodedSegment);
+}
+
+export function getSafeUrlNameForTemplate(templateUrl: string, urlName: string): string {
+  const placeholderIndex = templateUrl.indexOf("{urlName}");
+  const queryIndex = templateUrl.indexOf("?");
+  if (queryIndex !== -1 && placeholderIndex > queryIndex) {
+    return encodeURIComponent(urlName);
+  }
+
+  return urlName.split("/").map(encodePathSegment).join("/");
+}
+
+export function buildClickthroughUrl(templateUrl: string, urlName: string): string {
+  if (!templateUrl) {
+    return "";
+  }
+
+  return templateUrl.includes("{urlName}")
+    ? templateUrl.replace("{urlName}", getSafeUrlNameForTemplate(templateUrl, urlName))
+    : templateUrl;
+}
+
+function addAllowedHost(allowedHosts: Set<string>, hostname: string | undefined): void {
+  if (hostname) {
+    allowedHosts.add(hostname.toLowerCase());
+  }
+}
+
+export function collectAllowedClickthroughHosts(service: Service): Set<string> {
+  const allowedHosts = new Set<string>();
+  addAllowedHost(allowedHosts, service.reminderDomain);
+
+  try {
+    addAllowedHost(allowedHosts, new URL(buildClickthroughUrl(service.clickthroughUrl || "", "")).hostname);
+  } catch {
+    // Services without parseable clickthrough URLs simply have no fallback host.
+  }
+
+  return allowedHosts;
+}
+
+function isAllowedClickthroughHost(hostname: string, allowedHosts: ReadonlySet<string>): boolean {
+  if (allowedHosts.size === 0) {
+    return false;
+  }
+
+  return allowedHosts.has(hostname.toLowerCase());
+}
+
+export function toSafeHttpsUrl(rawUrl: string, allowedHosts: ReadonlySet<string>): string {
+  const trimmedUrl = rawUrl.trim();
+  if (!trimmedUrl) {
+    return "";
+  }
+
+  try {
+    const parsedUrl = new URL(trimmedUrl);
+    if (
+      parsedUrl.protocol !== "https:" ||
+      !parsedUrl.hostname ||
+      !isAllowedClickthroughHost(parsedUrl.hostname, allowedHosts)
+    ) {
+      return "";
+    }
+
+    return parsedUrl.toString();
+  } catch {
+    return "";
+  }
+}
+
+export function resolveClickthroughUrl(
+  offerClickthroughUrl: string | undefined,
+  service: Service,
+  urlName: string
+): string {
+  const allowedHosts = collectAllowedClickthroughHosts(service);
+  const fallbackUrl = buildClickthroughUrl(service.clickthroughUrl || "", urlName);
+
+  return (
+    toSafeHttpsUrl(offerClickthroughUrl || "", allowedHosts) ||
+    toSafeHttpsUrl(fallbackUrl, allowedHosts)
+  );
+}
+
+export function restoreActionButtonHref(actionBtn: HTMLAnchorElement, href: string): void {
+  if (href) {
+    actionBtn.href = href;
+    actionBtn.target = "_blank";
+    actionBtn.rel = "noopener noreferrer";
+    actionBtn.removeAttribute("aria-disabled");
+  } else {
+    actionBtn.removeAttribute("href");
+    actionBtn.removeAttribute("target");
+    actionBtn.removeAttribute("rel");
+    actionBtn.setAttribute("aria-disabled", "true");
+  }
+}

--- a/src/ui/utils/clickthrough.ts
+++ b/src/ui/utils/clickthrough.ts
@@ -1,6 +1,6 @@
 import type { Service } from "../../config/services.js";
 
-function encodePathSegment(segment: string): string {
+export function encodePathSegment(segment: string): string {
   let decodedSegment = segment;
   try {
     decodedSegment = decodeURIComponent(segment);
@@ -8,12 +8,13 @@ function encodePathSegment(segment: string): string {
     // Keep malformed input and encode it below.
   }
 
+  // URL parsing treats %2E and %2E%2E as dot segments, so encode the percent signs too.
   if (decodedSegment === ".") {
-    return "%2E";
+    return "%252E";
   }
 
   if (decodedSegment === "..") {
-    return "%2E%2E";
+    return "%252E%252E";
   }
 
   return encodeURIComponent(decodedSegment);

--- a/src/ui/views/notification.ts
+++ b/src/ui/views/notification.ts
@@ -10,7 +10,7 @@ import type { FetchAdapter } from "../../network/types.js";
 import type { SessionStorageAdapter } from "../../storage/types.js";
 import type { Position } from "../../config/constants.js";
 import type { Service, ServiceRegistry } from "../../config/services.js";
-import { MESSAGE_SHOWN_KEY_PREFIX } from "../../config/constants.js";
+import { getMessageShownKey } from "../../config/constants.js";
 import { getNotificationStyles } from "../styles/index.js";
 import {
   createShadowHost,
@@ -32,6 +32,7 @@ export interface NotificationOptions {
   fetcher: FetchAdapter;
   sessionStorage: SessionStorageAdapter;
   currentHost: string;
+  currentPathname: string;
   onClose?: () => void;
 }
 
@@ -39,7 +40,7 @@ export interface NotificationOptions {
  * Create and show the main notification
  */
 export function createNotification(options: NotificationOptions): HTMLElement {
-  const { match, settings, services, i18n, fetcher, sessionStorage, currentHost, onClose } = options;
+  const { match, settings, services, i18n, fetcher, sessionStorage, currentHost, currentPathname, onClose } = options;
   const service = match.service;
 
   // Create shadow host
@@ -98,7 +99,15 @@ export function createNotification(options: NotificationOptions): HTMLElement {
   const checklist = createChecklist(service, i18n);
 
   // Action button
-  const { actionBtn, recheckIcon } = createActionButton(match, service, i18n, sessionStorage, currentHost, content);
+  const { actionBtn, recheckIcon } = createActionButton(
+    match,
+    service,
+    i18n,
+    sessionStorage,
+    currentHost,
+    currentPathname,
+    content
+  );
 
   // Hide site link
   const hideSiteLink = document.createElement("span");
@@ -439,6 +448,7 @@ function createActionButton(
   i18n: I18nAdapter,
   sessionStorage: SessionStorageAdapter,
   currentHost: string,
+  currentPathname: string,
   content: HTMLDivElement
 ): { actionBtn: HTMLAnchorElement; recheckIcon: HTMLSpanElement } {
   const actionBtn = document.createElement("a");
@@ -514,7 +524,7 @@ function createActionButton(
       e.preventDefault();
     }
 
-    sessionStorage.set(`${MESSAGE_SHOWN_KEY_PREFIX}${currentHost}`, Date.now().toString());
+    sessionStorage.set(getMessageShownKey(currentHost, currentPathname), Date.now().toString());
 
     // Info-type services: just let the link open naturally
     if (service.type === "info") {

--- a/src/ui/views/notification.ts
+++ b/src/ui/views/notification.ts
@@ -22,6 +22,7 @@ import {
 import { getLogoIconForService, SETTINGS_ICON_URI } from "../components/icons.js";
 import { makeCornerDraggable, type CleanupFunction } from "../components/draggable.js";
 import { detectAdblock } from "../../core/adblock-detection.js";
+import { resolveClickthroughUrl, restoreActionButtonHref } from "../utils/clickthrough.js";
 
 export interface NotificationOptions {
   match: MatchResult;
@@ -204,8 +205,12 @@ export function createNotification(options: NotificationOptions): HTMLElement {
     }
   });
 
-  // Adblock detection (skip for code-based and info-type services)
-  if (service.type !== "code" && service.type !== "info") {
+  // Adblock detection (skip for code-based, info-type, and disabled tracking services)
+  if (
+    service.type !== "code" &&
+    service.type !== "info" &&
+    actionBtn.getAttribute("aria-disabled") !== "true"
+  ) {
     const originalHref = actionBtn.getAttribute("href") || "";
     const originalText = actionBtn.childNodes[0]?.textContent || "";
 
@@ -225,16 +230,14 @@ export function createNotification(options: NotificationOptions): HTMLElement {
           if (actionBtn.childNodes[0]) {
             actionBtn.childNodes[0].textContent = i18n.getMessage("adblockerDetected");
           }
-          actionBtn.removeAttribute("href");
-          actionBtn.removeAttribute("target");
+          restoreActionButtonHref(actionBtn, "");
         } else {
           actionBtn.classList.remove("adblock");
           actionBtn.style.animation = "";
           if (actionBtn.childNodes[0]) {
             actionBtn.childNodes[0].textContent = originalText;
           }
-          actionBtn.setAttribute("href", originalHref);
-          actionBtn.setAttribute("target", "_blank");
+          restoreActionButtonHref(actionBtn, originalHref);
         }
       } catch {
         // On error, restore original state
@@ -243,8 +246,7 @@ export function createNotification(options: NotificationOptions): HTMLElement {
         if (actionBtn.childNodes[0]) {
           actionBtn.childNodes[0].textContent = originalText;
         }
-        actionBtn.setAttribute("href", originalHref);
-        actionBtn.setAttribute("target", "_blank");
+        restoreActionButtonHref(actionBtn, originalHref);
       } finally {
         recheckIcon.classList.remove("spinning");
       }
@@ -264,8 +266,7 @@ export function createNotification(options: NotificationOptions): HTMLElement {
         if (actionBtn.childNodes[0]) {
           actionBtn.childNodes[0].textContent = i18n.getMessage("adblockerDetected");
         }
-        actionBtn.removeAttribute("href");
-        actionBtn.removeAttribute("target");
+        restoreActionButtonHref(actionBtn, "");
       }
     }).catch(() => {
       // Silently ignore detection failures
@@ -444,13 +445,12 @@ function createActionButton(
   actionBtn.className = "action-btn";
 
   // Build clickthrough URL
-  const baseUrl = service.clickthroughUrl || "";
-  const clickthroughUrl = baseUrl.includes("{urlName}")
-    ? baseUrl.replace("{urlName}", match.urlName || "")
-    : baseUrl;
-  actionBtn.target = "_blank";
-  actionBtn.rel = "noopener noreferrer";
-  actionBtn.href = clickthroughUrl;
+  const clickthroughUrl = resolveClickthroughUrl(
+    match.offer.clickthroughUrl,
+    service,
+    match.urlName || ""
+  );
+  restoreActionButtonHref(actionBtn, clickthroughUrl);
 
   // For code-based services, show the rebate code
   if (service.type === "code" && match.offer?.code) {
@@ -465,6 +465,11 @@ function createActionButton(
     copyIcon.textContent = "📋";
     copyIcon.title = i18n.getMessage("copyCode") || "Kopier kode";
     actionBtn.appendChild(copyIcon);
+  } else if (!clickthroughUrl) {
+    const trackingUnavailable = i18n.getMessage("trackingUnavailable");
+    actionBtn.textContent = trackingUnavailable;
+    actionBtn.title = trackingUnavailable;
+    actionBtn.setAttribute("aria-label", trackingUnavailable);
   } else if (service.type === "info") {
     actionBtn.textContent = i18n.getMessage("readMoreAboutDiscount");
   } else {
@@ -484,16 +489,29 @@ function createActionButton(
   }
   actionBtn.appendChild(recheckIcon);
 
+  const replayAdblockFeedback = () => {
+    actionBtn.style.animation = "shake 0.3s ease-in-out";
+    actionBtn.addEventListener("animationend", () => {
+      actionBtn.style.animation = "pulse 0.7s infinite alternate ease-in-out";
+    }, { once: true });
+  };
+
   // Click handler
   actionBtn.addEventListener("click", (e) => {
     // Don't proceed if adblock is detected - shake to indicate disabled
     if (actionBtn.classList.contains("adblock")) {
       e.preventDefault();
-      actionBtn.style.animation = "shake 0.3s ease-in-out";
-      actionBtn.addEventListener("animationend", () => {
-        actionBtn.style.animation = "pulse 0.7s infinite alternate ease-in-out";
-      }, { once: true });
+      replayAdblockFeedback();
       return;
+    }
+
+    const isDisabled = actionBtn.getAttribute("aria-disabled") === "true";
+    if (isDisabled && service.type !== "code") {
+      e.preventDefault();
+      return;
+    }
+    if (isDisabled) {
+      e.preventDefault();
     }
 
     sessionStorage.set(`${MESSAGE_SHOWN_KEY_PREFIX}${currentHost}`, Date.now().toString());

--- a/tests/clickthrough.test.ts
+++ b/tests/clickthrough.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, test } from "bun:test";
+import type { Service } from "../src/config/services.ts";
+import {
+  buildClickthroughUrl,
+  collectAllowedClickthroughHosts,
+  encodePathSegment,
+  getSafeUrlNameForTemplate,
+  resolveClickthroughUrl,
+  toSafeHttpsUrl,
+} from "../src/ui/utils/clickthrough.ts";
+
+function service(overrides: Partial<Service> = {}): Service {
+  return {
+    id: "example",
+    name: "Example",
+    color: "#000000",
+    clickthroughUrl: "https://portal.example.com/shop/{urlName}",
+    reminderDomain: "Reminder.Example.com",
+    ...overrides,
+  };
+}
+
+describe("encodePathSegment", () => {
+  test("encodes malformed percent input and dot path tokens", () => {
+    expect(encodePathSegment("%E0%A4%A")).toBe("%25E0%25A4%25A");
+    expect(encodePathSegment(".")).toBe("%252E");
+    expect(encodePathSegment("..")).toBe("%252E%252E");
+    expect(encodePathSegment("store name")).toBe("store%20name");
+  });
+});
+
+describe("template URL builders", () => {
+  test("encodes urlName as path segments when placeholder is in the path", () => {
+    expect(
+      getSafeUrlNameForTemplate(
+        "https://portal.example.com/shop/{urlName}",
+        "store name/../%E0%A4%A"
+      )
+    ).toBe("store%20name/%252E%252E/%25E0%25A4%25A");
+
+    expect(
+      buildClickthroughUrl(
+        "https://portal.example.com/shop/{urlName}",
+        "store name/.."
+      )
+    ).toBe("https://portal.example.com/shop/store%20name/%252E%252E");
+  });
+
+  test("encodes urlName as a single component when placeholder is in the query", () => {
+    expect(
+      getSafeUrlNameForTemplate(
+        "https://portal.example.com/search?q={urlName}",
+        "store/name value"
+      )
+    ).toBe("store%2Fname%20value");
+
+    expect(buildClickthroughUrl("https://portal.example.com/static", "ignored")).toBe(
+      "https://portal.example.com/static"
+    );
+  });
+});
+
+describe("collectAllowedClickthroughHosts", () => {
+  test("normalizes reminder and parsed clickthrough hosts", () => {
+    const hosts = collectAllowedClickthroughHosts(
+      service({ clickthroughUrl: "https://Shop.Example.org/path/{urlName}" })
+    );
+
+    expect([...hosts].sort()).toEqual(["reminder.example.com", "shop.example.org"]);
+  });
+
+  test("ignores invalid clickthrough templates", () => {
+    const hosts = collectAllowedClickthroughHosts(
+      service({ clickthroughUrl: "not a url {urlName}" })
+    );
+
+    expect([...hosts]).toEqual(["reminder.example.com"]);
+  });
+});
+
+describe("toSafeHttpsUrl", () => {
+  const allowedHosts = new Set(["portal.example.com"]);
+
+  test("accepts HTTPS URLs on allowed hosts", () => {
+    expect(toSafeHttpsUrl("https://portal.example.com/path?x=1", allowedHosts)).toBe(
+      "https://portal.example.com/path?x=1"
+    );
+  });
+
+  test("rejects non-HTTPS, unknown hosts, and malformed URLs", () => {
+    expect(toSafeHttpsUrl("http://portal.example.com/path", allowedHosts)).toBe("");
+    expect(toSafeHttpsUrl("https://evil.example.com/path", allowedHosts)).toBe("");
+    expect(toSafeHttpsUrl("%not-a-url", allowedHosts)).toBe("");
+  });
+});
+
+describe("resolveClickthroughUrl", () => {
+  test("prefers a safe offer clickthrough URL over the service fallback", () => {
+    expect(
+      resolveClickthroughUrl("https://portal.example.com/direct", service(), "fallback")
+    ).toBe("https://portal.example.com/direct");
+  });
+
+  test("falls back to the sanitized service URL when the offer URL is unsafe", () => {
+    expect(
+      resolveClickthroughUrl("https://evil.example.com/direct", service(), "store name/..")
+    ).toBe("https://portal.example.com/shop/store%20name/%252E%252E");
+  });
+
+  test("returns empty when neither offer nor fallback URL is safe", () => {
+    expect(
+      resolveClickthroughUrl(
+        "http://portal.example.com/direct",
+        service({ clickthroughUrl: "not a url {urlName}", reminderDomain: undefined }),
+        "fallback"
+      )
+    ).toBe("");
+  });
+});


### PR DESCRIPTION
## Summary
- add shared offer metadata for per-offer clickthrough URLs and path-specific merchant matching
- centralize safe clickthrough URL resolution and action-button disabled/adblock state handling
- scope notification cooldown by host + pathname so path-specific offers are not hidden by another path
- add focused Bun tests for clickthrough URL encoding, allowlisting, HTTPS enforcement, and fallback behavior
- add localized tracking-unavailable text and regenerate bundled artifacts

## Validation
- bun run test
- bun run typecheck
- bun run build:src
- jq empty _locales/*/messages.json data/sitelist.json sitelist.json data/services.json .feed-health.json manifest.json package.json
- git diff --check